### PR TITLE
fixed error when moving items 4281

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -23,6 +23,9 @@ var $testElement = $('#testelement');
 
 var debounceSave = _.debounce(save, 500);
 
+// Indicate dragging state
+var dragging = false;
+
 setTimeout(function() {
   // SORTING PANELS
   $('.panel-group').sortable({
@@ -34,6 +37,7 @@ setTimeout(function() {
     cursor: '-webkit-grabbing; -moz-grabbing;',
     axis: 'y',
     start: function(event, ui) {
+      dragging = true;
       var itemId = $(ui.item).data('id');
       var itemProvider = _.find(linkPromises, function(provider) {
         return provider.id === itemId;
@@ -70,6 +74,8 @@ setTimeout(function() {
         return sortedIds.indexOf(item.id);
       });
       $('.panel').not(ui.item).removeClass('faded');
+
+      dragging = false;
 
       save(false, true);
     },
@@ -171,6 +177,10 @@ $(".tab-content")
     save();
   })
   .on('show.bs.collapse', '.panel-collapse', function() {
+    if (dragging) {
+      return;
+    }
+
     // Get item ID / Get provider / Get item
     var itemID = $(this).parents('.panel').data('id');
     var itemProvider = _.find(linkPromises, function(provider) {


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4281
## Description
We added an additional variable dragging to prevent the creation of an additional provider while dragging an item that caused an error and did not allow saving changes due to the error.
## Backward compatibility
This change is fully backward compatible.