### PR TITLE
Changes component to use the standard file picker when picking images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/*
+.history

--- a/css/interface.css
+++ b/css/interface.css
@@ -14,7 +14,6 @@ body {
   border: 0;
   width: 100%;
   background-color: transparent;
-  padding: 15px;
 }
 
 .add-link .fl-widget-provider {

--- a/js/interface.js
+++ b/js/interface.js
@@ -250,10 +250,17 @@ function initLinkProvider(item) {
 var imageProvider;
 
 function initImageProvider(item) {
-  imageProvider = Fliplet.Widget.open('com.fliplet.image-manager', {
+  var filePickerData = {
+    selectFiles: item.imageConf ? [item.imageConf] : [],
+    selectMultiple: false,
+    type: 'image',
+    autoSelectOnUpload: true
+  };
+  
+  imageProvider = Fliplet.Widget.open('com.fliplet.file-picker', {
     // Also send the data I have locally, so that
     // the interface gets repopulated with the same stuff
-    data: item.imageConf,
+    data: filePickerData,
     // Events fired from the provider
     onEvent: function(event, data) {
       if (event === 'interface-validate') {
@@ -283,8 +290,8 @@ function initImageProvider(item) {
 
   imageProvider.then(function(data) {
     if (data.data) {
-      item.imageConf = data.data;
-      $('[data-id="' + item.id + '"] .thumb-image img').attr("src", data.data.thumbnail);
+      item.imageConf = data.data[0];
+      $('[data-id="' + item.id + '"] .thumb-image img').attr("src", data.data[0].thumbnail);
       save();
     }
     imageProvider = null;


### PR DESCRIPTION
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4909

## Description
Changed image provider to file picker

## Screenshots/screencasts
![issue-4909](https://user-images.githubusercontent.com/53430352/64538604-99da9300-d325-11e9-8362-1ef7827be234.gif)


## Backward compatibility

This change is fully backward compatible.