### PR TITLE
OD-562 [Fix] Fixed an issue with unresponsive save button

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -276,6 +276,7 @@ function initImageProvider(item) {
   window.addEventListener('message', function(event) {
     if (event.data === 'cancel-button-pressed') {
       Fliplet.Widget.toggleCancelButton(true);
+      Fliplet.Widget.toggleSaveButton(true);
       imageProvider.close();
 
       if (_.isEmpty(item.imageConf)) {


### PR DESCRIPTION
@sofiiakvasnevska @inna-bieshulia

OD-562 https://weboo.atlassian.net/browse/OD-562

Description
Fixed unresponsive save button
**Problem:** Canceling "select image" flow leaves the "save" button inactive because the "cancel" button did not call method to activate it back.
**Solution:** Trigger for enabling "save" button was added to "cancel" button handler.

Screenshots/screencasts
https://storyxpress.co/video/ksrljeyo40ekmuxf6

Backward compatibility
This change is fully backward compatible.

Reviewers
@upplabs-alex-levchenko